### PR TITLE
Expose public funcs

### DIFF
--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func main() {
 	tileJSON.MinZoom = zooms[0]
 	tileJSON.MaxZoom = zooms[len(zooms)-1]
 
-	tiles := listTiles(zooms, tileJSON)
+	tiles := ListTiles(zooms, tileJSON)
 	if args.TilesFile != "" {
 		extraTiles, err := tilesFromFile(args.TilesFile)
 		if err != nil {
@@ -271,7 +271,7 @@ func main() {
 		numWorkers = tileLen
 	}
 	// round robin the tiles so workers are hitting similar geospatial entries and zoom at the same time
-	rrTiles := roundRobinTiles(tiles, numWorkers)
+	rrTiles := RoundRobinTiles(tiles, numWorkers)
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
 		workerTiles := rrTiles[i]

--- a/mbtiles.go
+++ b/mbtiles.go
@@ -74,7 +74,7 @@ func CreateMetadata(tj *TileJSON, opts CreateMetadataOptions) MbTilesMetadata {
 		}
 		meta["center"] = center
 	}
-	
+
 	// mbtiles spec requires the json field for vector format and it's not meaningful for rasters
 	if opts.Format == Pbf {
 		metaJSONField := CreateMetadataJSON(tj)

--- a/mbtiles.go
+++ b/mbtiles.go
@@ -14,10 +14,10 @@ type MbTilesMetadata map[string]string
 type MbTilesFormat string
 
 const (
-	Pbf  MbTilesFormat = "pbf"
-	Jpg  MbTilesFormat = "jpg"
-	Png  MbTilesFormat = "png"
-	WebP MbTilesFormat = "webp"
+	MbTilesFormatPbf  MbTilesFormat = "pbf"
+	MbTilesFormatJpg  MbTilesFormat = "jpg"
+	MbTilesFormatPng  MbTilesFormat = "png"
+	MbTilesFormatWebP MbTilesFormat = "webp"
 )
 
 type CreateMetadataOptions struct {
@@ -32,7 +32,7 @@ type CreateMetadataOptions struct {
 func CreateMetadata(tj *TileJSON, opts CreateMetadataOptions) MbTilesMetadata {
 	format := opts.Format
 	if string(format) == "" {
-		format = Pbf
+		format = MbTilesFormatPbf
 	}
 	meta := MbTilesMetadata{
 		"name":   tj.Name,
@@ -76,7 +76,7 @@ func CreateMetadata(tj *TileJSON, opts CreateMetadataOptions) MbTilesMetadata {
 	}
 
 	// mbtiles spec requires the json field for vector format and it's not meaningful for rasters
-	if opts.Format == Pbf {
+	if opts.Format == MbTilesFormatPbf {
 		metaJSONField := CreateMetadataJSON(tj)
 		if metaJSONBytes, err := json.Marshal(metaJSONField); err == nil {
 			meta["json"] = string(metaJSONBytes)

--- a/tileutils.go
+++ b/tileutils.go
@@ -27,7 +27,8 @@ type BoundingBox struct {
 	Bottom float64
 }
 
-func listTiles(zooms []int, tj *TileJSON) []TileCoords {
+// ListTiles returns a list of all the tiles within the given zooms based on the TileJSON
+func ListTiles(zooms []int, tj *TileJSON) []TileCoords {
 	tiles := make([]TileCoords, 0, 2<<zooms[len(zooms)-1])
 	for _, z := range zooms {
 		newTiles := tilesInBbox(BoundingBox{
@@ -90,8 +91,8 @@ func tilesInBbox(bbox BoundingBox, zoom int) []TileCoords {
 	return tiles
 }
 
-// roundRobinTiles assigns tiles to workers in round robin fashion
-func roundRobinTiles(input []TileCoords, numWorkers int) [][]TileCoords {
+// RoundRobinTiles assigns tiles to workers in round robin fashion
+func RoundRobinTiles(input []TileCoords, numWorkers int) [][]TileCoords {
 	out := make([][]TileCoords, numWorkers)
 	for i, v := range input {
 		index := i % numWorkers

--- a/writers.go
+++ b/writers.go
@@ -173,6 +173,7 @@ func NewWriters(args Args, tj *TileJSON) (writer TileWriter, bulkWriter TileBulk
 		meta := CreateMetadata(tj, CreateMetadataOptions{
 			Filename: args.TileJSON,
 			Version:  args.Version,
+			Format: Pbf,
 		})
 		err = mbWriter.BulkWriteMetadata(meta)
 		return

--- a/writers.go
+++ b/writers.go
@@ -173,7 +173,7 @@ func NewWriters(args Args, tj *TileJSON) (writer TileWriter, bulkWriter TileBulk
 		meta := CreateMetadata(tj, CreateMetadataOptions{
 			Filename: args.TileJSON,
 			Version:  args.Version,
-			Format: Pbf,
+			Format:   Pbf,
 		})
 		err = mbWriter.BulkWriteMetadata(meta)
 		return

--- a/writers.go
+++ b/writers.go
@@ -173,7 +173,7 @@ func NewWriters(args Args, tj *TileJSON) (writer TileWriter, bulkWriter TileBulk
 		meta := CreateMetadata(tj, CreateMetadataOptions{
 			Filename: args.TileJSON,
 			Version:  args.Version,
-			Format:   Pbf,
+			Format:   MbTilesFormatPbf,
 		})
 		err = mbWriter.BulkWriteMetadata(meta)
 		return


### PR DESCRIPTION
- Expose some tile util functions as public
- Tweaks to mbtiles `CreateMetadata` to remove hardcoded `format` and enable re-use for creating raster metadata json