### PR TITLE
fix: instructions for installing v2 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Go must be installed, version 1.20 or later.
 Then:
 
 ```
-go install github.com/flightaware/baremaps-exporter/cmd/baremaps-exporter/v2
+go install github.com/flightaware/baremaps-exporter/v2/cmd/baremaps-exporter
 ```
 
 Now you're ready to go.


### PR DESCRIPTION
The `v2` was in the wrong place.